### PR TITLE
Correct nginx_upstream_name configuration key

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -3,7 +3,7 @@ app_dll: DotnetApp.dll
 root_path: /var/www/app1
 update_zip_absolute_path: /home/ubuntu/DotnetApp.zip
 caddy_upstream_key: dotnetcore
-nginx_upstream_path:
+nginx_upstream_name: dotnetapp
 healthcheck: /test
 shared_files:
   - appsettings.Production.json


### PR DESCRIPTION
Update the example nginx_upstream_name  key. It was incorrectly named nginx_upstream_path